### PR TITLE
Example Showcase: Domain Events

### DIFF
--- a/src/main/java/com/classvar/examples/ExampleCommandProcessor.java
+++ b/src/main/java/com/classvar/examples/ExampleCommandProcessor.java
@@ -1,0 +1,21 @@
+package com.classvar.examples;
+
+import org.springframework.stereotype.Service;
+
+import javax.transaction.Transactional;
+
+@Service
+public class ExampleCommandProcessor {
+
+    private ExampleRepository exampleRepository;
+
+    public ExampleCommandProcessor(ExampleRepository exampleRepository) {
+        this.exampleRepository = exampleRepository;
+    }
+
+    @Transactional
+    public void doExampleOperation() {
+        ExampleEntity toCreate = new ExampleEntity("name");
+        exampleRepository.save(toCreate);
+    }
+}

--- a/src/main/java/com/classvar/examples/ExampleEntity.java
+++ b/src/main/java/com/classvar/examples/ExampleEntity.java
@@ -1,0 +1,30 @@
+package com.classvar.examples;
+
+import org.springframework.data.domain.AbstractAggregateRoot;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+
+@Entity
+public class ExampleEntity extends AbstractAggregateRoot<ExampleEntity> {
+
+    // MySQL
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    private String name;
+
+    protected ExampleEntity() {}
+
+    public ExampleEntity(String name) {
+        this.name = name;
+        this.registerEvent(new ExampleEntityCreated(this));
+    }
+
+    public String getName() {
+        return this.name;
+    }
+}

--- a/src/main/java/com/classvar/examples/ExampleEntityCreated.java
+++ b/src/main/java/com/classvar/examples/ExampleEntityCreated.java
@@ -1,0 +1,14 @@
+package com.classvar.examples;
+
+public class ExampleEntityCreated {
+
+    private ExampleEntity entity;
+
+    public ExampleEntityCreated(ExampleEntity entity) {
+        this.entity = entity;
+    }
+
+    public ExampleEntity getEntity() {
+        return this.entity;
+    }
+}

--- a/src/main/java/com/classvar/examples/ExampleEventListener.java
+++ b/src/main/java/com/classvar/examples/ExampleEventListener.java
@@ -1,0 +1,13 @@
+package com.classvar.examples;
+
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+@Component
+public class ExampleEventListener {
+
+    @EventListener
+    public void handle(ExampleEntityCreated event) {
+        // ... do something ...
+    }
+}

--- a/src/main/java/com/classvar/examples/ExampleRepository.java
+++ b/src/main/java/com/classvar/examples/ExampleRepository.java
@@ -1,0 +1,6 @@
+package com.classvar.examples;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ExampleRepository extends JpaRepository<ExampleEntity, Long> {
+}

--- a/src/test/java/com/classvar/examples/ExampleEntityDomainEventTest.java
+++ b/src/test/java/com/classvar/examples/ExampleEntityDomainEventTest.java
@@ -1,0 +1,27 @@
+package com.classvar.examples;
+
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+public class ExampleEntityDomainEventTest {
+
+    @Autowired
+    ExampleCommandProcessor processor;
+
+    @MockBean
+    ExampleEventListener listener;
+
+    @Test
+    public void DomainEventIsPublishedAfterTransaction() {
+        processor.doExampleOperation();
+
+        verify(listener, times(1)).handle(Mockito.isA(ExampleEntityCreated.class));
+    }
+}


### PR DESCRIPTION
단지 예제 코드이므로 병합하지 않습니다.

#### 예제 코드의 흐름

1. `ExampleCommandProcessor#doExampleOperation` 호출

2. `ExampleEntity`가 save됨

3. Transaction 수행 시 Spring Data Jpa에서 해당 엔터티(`ExampleEntity`)에 `@DomainEvents` 어노테이션이 붙은 필드를 보고 해당 이벤트를 발행

4. `@EventListener`로 마킹된 핸들러가 호출

#### 테스트 결과
![image](https://user-images.githubusercontent.com/28754907/150160008-00a68c1c-186d-4267-94d1-daf21c369ff5.png)
